### PR TITLE
add information on how to run without security

### DIFF
--- a/1.8/registry/README.md
+++ b/1.8/registry/README.md
@@ -2,7 +2,9 @@
 
 The Docker [registry](https://docs.docker.com/registry/) is a stateless, highly scalable server side application that stores and lets you distribute Docker images. This DC/OS package provides a private registry that can be made available to any other component in the system through a [virtual IP](https://dcos.io/docs/1.8/usage/service-discovery/load-balancing-vips/virtual-ip-addresses/) with the default of `registry.marathon.l4lb.thisdcos.directory:5000`.
 
-Note that this package will install with the default parameters, but Docker registry requires a valid TLS certificate and key to work properly and secure connections between the engines and registry hosting the cache. Follow this document to learn how to configure a download location for the certificate and key in the Advanced Installation “security” section.
+Note that this package will install with the default parameters, but in order to provide secure communication, Docker registry requires a valid TLS certificate and key to work properly and secure connections between the engines and registry hosting the cache. Follow this document to learn how to configure a download location for the certificate and key in the Advanced Installation “security” section.
+
+In case you'd like to configure your nodes to use the Docker Registry without TLS security and skip all configuration related to TLS security and certificates, please check out the section [Using an insecure Docker registry](#insecure) for details on how to configure the Docker engine in the nodes in your DC/OS cluster to work with an insecure registry.
 
 - Estimated time for completion: up to 30 minutes
 - Target audience:
@@ -14,6 +16,7 @@ Note that this package will install with the default parameters, but Docker regi
 
 - [Prerequisites](#prerequisites)
 - [Install](#install)
+- [Insecure Registry](#insecure)
 - [Use](#use)
 - [Storage options](#storage-options)
 - [Uninstall](#uninstall)
@@ -191,6 +194,34 @@ $ for i in $MESOS_AGENTS; do ssh "$i" -oStrictHostKeyChecking=no 'sudo systemctl
 ```
 
 The package can now be installed from the Universe, using the bootstrap’s node IP address and TCP port to download the certificate and key file.
+
+## Insecure
+
+In case you'd like to run an insecure registry without using any TLS certificates, you can configure the nodes in your DC/OS cluster to work without certificates or security.
+
+This basically tells the Docker engine in each node to entirely disregard security for your registry. While this is relatively easy to configure the daemon in this way, it is very insecure. It does expose your registry to trivial MITM. Only use this solution for isolated testing or in a tightly controlled, air-gapped environment.
+
+```bash
+$ sudo tee /etc/systemd/system/docker.service.d/override.conf  <<-'EOF'
+[Service]
+EnvironmentFile=-/etc/sysconfig/docker
+EnvironmentFile=-/etc/sysconfig/docker-storage
+EnvironmentFile=-/etc/sysconfig/docker-network
+ExecStart=
+ExecStart=/usr/bin/docker daemon -H fd:// $OPTIONS \
+         $DOCKER_STORAGE_OPTIONS \
+         $DOCKER_NETWORK_OPTIONS \
+         $BLOCK_REGISTRY \
+         $INSECURE_REGISTRY \
+         --storage-driver=overlay \
+         --insecure-registry registry.marathon.l4lb.thisdcos.directory:5000 
+EOF
+
+systemctl daemon-reload
+systemctl restart docker
+```
+
+For more information on running without security, please check the [Docker documentation](https://docs.docker.com/registry/insecure/).
 
 ## Install
 

--- a/1.8/registry/README.md
+++ b/1.8/registry/README.md
@@ -201,6 +201,8 @@ In case you'd like to run an insecure registry without using any TLS certificate
 
 This basically tells the Docker engine in each node to entirely disregard security for your registry. While this is relatively easy to configure the daemon in this way, it is very insecure. It does expose your registry to trivial MITM. Only use this solution for isolated testing or in a tightly controlled, air-gapped environment.
 
+Run this in all agent nodes of your cluster:
+
 ```bash
 $ sudo tee /etc/systemd/system/docker.service.d/override.conf  <<-'EOF'
 [Service]


### PR DESCRIPTION
By default, the package installs without TLS. This explains how to configure the nodes to work without TLS in an insecure way.