### PR TITLE
fix portworx package config.json

### DIFF
--- a/1.8/portworx/README.md
+++ b/1.8/portworx/README.md
@@ -77,11 +77,10 @@ Log into a terminal where the DC/OS CLI is installed and has connectivity with t
   },
   "portworx": {
     "cpus": 1,
-    "mem": 1024
-    "properties": {
-    "clusterid": "mycluster",
-    "storage": "/dev/sdb",
+    "mem": 1024,
     "kvdb": "etcd://10.1.2.3:4001",
+    "clusterid": "mycluster",
+    "storage": "/dev/sdb"
   }
 }
 ```


### PR DESCRIPTION
The portworx package config.json had a few errors - I've manually tested these changes and they were accepted using the following command:

```bash
$ dcos package install --yes --options ./px-options.json portworx
```

The error the previous config was giving:

```
$ dcos package install --yes --options ./px-options.json portworx
Error: Options JSON failed validation
Unexpected properties: ['properties']
Path: portworx

Please create a JSON file with the appropriate options, and pass the /path/to/file as an --options argument.
```