### PR TITLE
[ceph] using mon listening port

### DIFF
--- a/1.8/ceph/README.md
+++ b/1.8/ceph/README.md
@@ -427,11 +427,13 @@ NOTE: If you're using [Network Security]((#network-security), make sure to use t
 ```bash
 export HOST_NETWORK=0.0.0.0/0 
 rpm --rebuilddb && yum install -y bind-utils
-export MONITORS=$(for i in $(dig srv _mon._tcp.ceph.mesos|awk '/^_mon._tcp.ceph.mesos/'|awk '{print $8":"$7}'); do echo -n $i',';done)
+#export MONITORS=$(for i in $(dig srv _mon._tcp.ceph.mesos|awk '/^_mon._tcp.ceph.mesos/'|awk '{print $8":"$7}'); do echo -n $i',';done)
+export PORT_MON=$(dig srv _mon._tcp.ceph.mesos|awk '/^_mon._tcp.ceph.mesos/'|head -n 1|awk '{print $7}') #assume all mons are in the same port, pick first
 cat <<-EOF > /etc/ceph/ceph.conf
 [global]
 fsid = $(echo "$SECRETS" | jq .fsid)
-mon host = "${MONITORS::-1}"
+#mon host = "${MONITORS::-1}"
+mon host = "mon.ceph.mesos:$PORT_MON"
 auth cluster required = cephx
 auth service required = cephx
 auth client required = cephx


### PR DESCRIPTION
Using mon.ceph.mesos:$PORT_MON instead of using all monitors
Thanks to: https://github.com/fernandosanchezmunoz/DCOS_installer/commit/df7388db98254586bf0d1d70fbc4a472d285beb1
and https://github.com/fernandosanchezmunoz/DCOS_installer/commit/65b201cf3a108e24f2e04cc53b23d77a7b0883ee

It should work better for ceph nodes that changes their hostname (due to restart for example).