### PR TITLE
Updated Scale with example for DCOS 1.10

### DIFF
--- a/scale/1.10/README.md
+++ b/scale/1.10/README.md
@@ -23,9 +23,9 @@
 
 ## Prerequisites
 
-- A running DC/OS 1.9 cluster with a minimum of 3 nodes, each with at least 4 CPU and 6 GB of RAM available.
+- A running DC/OS 1.10 cluster with a minimum of 3 nodes, each with at least 4 CPU and 6 GB of RAM available.
 - [Elasticsearch](https://github.com/dcos/examples/tree/master/elasticsearch) package running within the DCOS cluster.
-- [DC/OS CLI](https://dcos.io/docs/1.9/usage/cli/install/) installed.
+- [DC/OS CLI](https://dcos.io/docs/1.10/cli/install/) installed.
 - [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/installing.html) installed and _configured with an IAM user granted AdministratorAccess role_.
 
 ## Install Scale
@@ -38,7 +38,7 @@ This DC/OS Service is currently in preview. We recommend a minimum of three node
 
 Tutorial documentation for Scale can be found here: https://github.com/dcos/examples/tree/master/scale
 Continue installing? [yes/no] yes
-Installing Marathon app for package [scale] version [5.0.0-0.1.0]
+Installing Marathon app for package [scale] version [5.1.1-0.1.0]
 The Scale DCOS Service has been successfully installed!
 New User Tutorial: https://github.com/dcos/examples/tree/master/scale
 ```

--- a/scale/README.md
+++ b/scale/README.md
@@ -1,3 +1,5 @@
 Select your DC/OS version:
 
 [1.9](1.9)
+
+[1.10](1.10)


### PR DESCRIPTION
No changes to example documentation from DCOS 1.9. I had to make some fairly far reaching updates to our deployment for Scale as a result of breaking updates to Marathon - these are included in Scale 5.1.1. This PR should be evaluated following PR to bump Scale to 5.1.1 in Universe: https://github.com/mesosphere/universe/pull/1405

Resolves https://jira.mesosphere.com/browse/DCOS_COMMUNITY-142