### PR TITLE
Update Cassandra contact-points

### DIFF
--- a/kong/1.9/README.md
+++ b/kong/1.9/README.md
@@ -156,7 +156,7 @@ and [Marathon-LB](https://dcos.io/docs/1.9/networking/marathon-lb/).
           "password": "kong"
         },
         "cassandra": {
-          "contact-points": "node-0.cassandra.mesos, node-1.cassandra.mesos, node-2.cassandra.mesos",
+          "contact-points": "node.cassandra.l4lb.thisdcos.directory",
           "port": 9042,
           "keyspace": "kong"
         }


### PR DESCRIPTION
- Cassandra default endpoint updated to match
  https://docs.mesosphere.com/service-docs/cassandra/v2.0.0-3.0.14/connecting-clients/

For https://github.com/mesosphere/universe/pull/1444