### PR TITLE
Add deprecation notice to Artifactory example

### DIFF
--- a/artifactory/1.10/README.md
+++ b/artifactory/1.10/README.md
@@ -1,4 +1,6 @@
 # How to use Artifactory on DC/OS
+**&ast;&ast;&ast; *Deprecation NOTICE* &ast;&ast;&ast;**  
+*The Artifactory on DC/OS integration is deprecated and no longer maintained. Please use another [installation](https://www.jfrog.com/confluence/display/RTF/Installing+Artifactory) method.*
 
 Currently you are only able to use licensed versions of Artifactory on DC/OS. To
 get a trial license, go to [JFrog's

--- a/artifactory/1.11/README.md
+++ b/artifactory/1.11/README.md
@@ -1,4 +1,6 @@
 # How to use Artifactory on DC/OS
+**&ast;&ast;&ast; *Deprecation NOTICE* &ast;&ast;&ast;**  
+*The Artifactory on DC/OS integration is deprecated and no longer maintained. Please use another [installation](https://www.jfrog.com/confluence/display/RTF/Installing+Artifactory) method.*
 
 Currently you are only able to use licensed versions of Artifactory on DC/OS. To
 get a trial license, go to [JFrog's

--- a/artifactory/1.8/README.md
+++ b/artifactory/1.8/README.md
@@ -1,4 +1,6 @@
 # How to use Artifactory on DC/OS
+**&ast;&ast;&ast; *Deprecation NOTICE* &ast;&ast;&ast;**  
+*The Artifactory on DC/OS integration is deprecated and no longer maintained. Please use another [installation](https://www.jfrog.com/confluence/display/RTF/Installing+Artifactory) method.*
 
 Currently you are only able to use licensed versions of Artifactory on DC/OS. To get a trial license, go to [JFrog's website](https://www.jfrog.com/artifactory/free-trial-mesosphere/).
 

--- a/artifactory/1.9/README.md
+++ b/artifactory/1.9/README.md
@@ -1,4 +1,6 @@
 # How to use Artifactory on DC/OS
+**&ast;&ast;&ast; *Deprecation NOTICE* &ast;&ast;&ast;**  
+*The Artifactory on DC/OS integration is deprecated and no longer maintained. Please use another [installation](https://www.jfrog.com/confluence/display/RTF/Installing+Artifactory) method.*
 
 Currently you are only able to use licensed versions of Artifactory on DC/OS. To get a trial license, go to [JFrog's website](https://www.jfrog.com/artifactory/free-trial-mesosphere/).
 

--- a/artifactory/README.md
+++ b/artifactory/README.md
@@ -1,4 +1,6 @@
 Select your DC/OS version:
+**&ast;&ast;&ast; *Deprecation NOTICE* &ast;&ast;&ast;**  
+*The Artifactory on DC/OS integration is deprecated and no longer maintained. Please use another [installation](https://www.jfrog.com/confluence/display/RTF/Installing+Artifactory) method.*
 
 [1.8](1.8)
 

--- a/artifactory/README.md
+++ b/artifactory/README.md
@@ -1,4 +1,5 @@
 Select your DC/OS version:
+
 **&ast;&ast;&ast; *Deprecation NOTICE* &ast;&ast;&ast;**  
 *The Artifactory on DC/OS integration is deprecated and no longer maintained. Please use another [installation](https://www.jfrog.com/confluence/display/RTF/Installing+Artifactory) method.*
 


### PR DESCRIPTION
The example relies on a very old version of Artifactory. This integration is no longer maintained by JFrog. Adding deprecation notice to avoid confusing new users.